### PR TITLE
fix: add putMultipart to HttpClientInterface

### DIFF
--- a/src/Client/Contracts/HttpClientInterface.php
+++ b/src/Client/Contracts/HttpClientInterface.php
@@ -15,4 +15,6 @@ interface HttpClientInterface
     public function delete(string $uri, array $options = []): array;
 
     public function postMultipart(string $uri, array $multipart = [], array $options = []): array;
+
+    public function putMultipart(string $uri, array $multipart = [], array $options = []): array;
 }


### PR DESCRIPTION
## Problem

HikvisionClient calls `HttpClientInterface::putMultipart()`, but the method
is not declared in `HttpClientInterface`.

This causes static analysis and IDE error PHP0418:

Call to unknown method HttpClientInterface::putMultipart().

## Change

Add the `putMultipart()` declaration to `HttpClientInterface` using the
same signature already implemented by `HttpClient`.

## Testing

The existing `HttpClient` implementation already provides this method,
so no implementation change is required.