### PR TITLE
docs: record Sprint 2 and what running it found

### DIFF
--- a/docs/startup/03-yol-xaritasi.md
+++ b/docs/startup/03-yol-xaritasi.md
@@ -83,18 +83,78 @@ Integratsiya ikkala tomonning testlari ko'rmagan xatoni topdi: agent `/agent/v1/
 ### 🚦 Gate
 Agent ishladi. Arxitektura qayta ko'rib chiqilmaydi.
 
-## Sprint 2 — Bulut skeleti va voqealar (2 hafta)
+## Sprint 2 — Bulut skeleti va voqealar (2 hafta) — ✅ BAJARILDI 2026-08-26
 
-- [ ] `davomat-cloud` repo: Laravel 12 + Filament v4 + Postgres + Redis/Horizon
-- [ ] Auth, `organizations`, `memberships`, rollar, tenant global scope
-- [ ] Filament: filial, agent, qurilma ro'yxatlari; enroll token generatsiyasi
-- [ ] `access_events` jadvali + dedup unique index
-- [ ] Agent endpointlarini bulutga ko'chirish, HMAC imzo bilan himoyalash
-- [ ] Voqealar ekrani: filtr (filial, qurilma, sana, xodim)
-- [ ] Tenant izolyatsiyasi uchun feature testlar
+- [x] `attendance-cloud` repo: **Laravel 13 + Filament v5** + SQLite (test) / Postgres (prod)
+- [x] Auth, `organizations`, `memberships`, rollar, tenant global scope
+- [x] Filament: filial, agent, qurilma ro'yxatlari; enroll token generatsiyasi
+- [x] `access_events` jadvali + dedup unique index
+- [x] Agent endpointlari, HMAC imzo bilan himoyalangan
+- [x] Voqealar ekrani: filtr (filial, terminal, tur, xodim, sana)
+- [x] Tenant izolyatsiyasi uchun feature testlar
+- [ ] Redis / Horizon — hali kerak emas, navbat `database` drayverida
 
-### ✅ Demo
-HR panelga kiradi, filial yaratadi, token oladi, agent ulanadi, qurilma ko'rinadi, kirish-chiqishlar jonli oqadi.
+### Rejadan farqlar
+
+| Reja | Amalda | Sabab |
+|---|---|---|
+| `davomat-cloud` | `attendance-cloud` | Repo Sprint 1 da shu nom bilan yaratilgan |
+| Laravel 12 + Filament v4 | Laravel 13 + Filament v5 | Ikkalasi ham chiqib bo'lgan; eski versiyani tanlash qarzdan boshqa narsa emas |
+| Redis / Horizon | Yo'q | Hozircha fon vazifalari yo'q. Kerak bo'lganda qo'shiladi |
+
+### Tenancy qanday ishlaydi
+
+Har bir kirish nuqtasi so'rovga **bitta tashkilotni** qo'yadi — agent HMAC'idan yoki
+tizimga kirgan foydalanuvchi a'zoligidan — va `organization_id` ustuni bor har bir
+model global scope bilan cheklanadi. Kontrollerlar `where` ni takrorlamaydi, ya'ni
+uni unutish boshqa mijoz ma'lumotini ochib yubormaydi. Chegaradan chiqish mumkin,
+lekin yozib qo'yish shart: `Model::acrossOrganizations()`, u atigi ikki joyda bor —
+agentni topish va enrolment, ikkalasi ham tashkilotni bilishdan **oldin** ishlaydi.
+
+### ✅ Demo — o'tkazildi
+
+Haqiqiy agent jarayoni, haqiqiy HTTP, bitta mashinada:
+
+```
+enroll                        → agt_v9kh8...
+enroll (o'sha token qayta)    → 401 invalid_token
+heartbeat                     → bulutda dev_kirish paydo bo'ldi (branch=1, org=1)
+multipart callback → agent    → 1 voqea: emp=1042, credential=face, source=webhook
+o'sha callback qayta          → hamon 1 voqea (dedup)
+GET /admin/access-events      → 302 → /admin/login
+```
+
+Panelga brauzerdan kirish jonli o'tkazilmadi; u to'liq middleware zanjiri orqali
+ishlaydigan HTTP testlari bilan qoplangan.
+
+### Demo nimani ko'rsatdi
+
+**Uchta xato, uchalasi ham faqat haqiqiy ishga tushirganda chiqdi.**
+
+1. **Qurilma bulutda o'z-o'zidan paydo bo'lmasdi.** Panel terminallarni ko'rsatardi,
+   lekin ularni hech nima yaratmasdi — ro'yxatni faqat qo'lda to'ldirish mumkin edi.
+   Endi heartbeat notanish terminalni ro'yxatdan o'tkazadi. Bu tilak ro'yxati bilan
+   LAN'da haqiqatan turgan narsa o'rtasidagi farq.
+
+2. **`devices.device_id` butun o'rnatma bo'yicha unique edi.** Bu dedup kalitidan
+   farqli — bu yerda to'qnashuv kutilmagan hol emas, **kutiladigan** hol: id ni
+   agentni o'rnatgan odam yozadi va ikkinchi mijoz ham `dev_kirish` deb nomlaydi.
+   Global unique degani o'sha mijozning terminali umuman ro'yxatdan o'tolmasligi.
+
+3. **Livewire yangilanishlari panel middleware'idan o'tmaydi.** Livewire'ning update
+   endpointi faqat `web` guruhini olib yuradi, ya'ni saralash, filtr yoki sahifa
+   almashtirish panel zanjirini qayta ishga tushirmaydi — agar u `isPersistent`
+   deb ro'yxatdan o'tkazilmagan bo'lsa. Bu sizishning eng yomon shakli: birinchi
+   sahifa to'g'ri chiqadi, kimdir ustun sarlavhasini bosgunicha.
+
+Uchinchisini sinash uchun ikki marta xato qildim va ikkalasini ham tuzatdim:
+`Livewire::test()` uni umuman ushlay olmaydi (u middleware o'chirilgan sintetik
+endpoint orqali render qiladi), va haqiqiy so'rov bilan yozilgan test ham avval
+noto'g'ri sababdan o'tdi — test bitta konteynerni `GET` va `POST` orasida
+qayta ishlatgani uchun ijaraga olingan tashkilot sizib o'tgan edi.
+
+### 🚦 Gate
+Bulut skeleti tayyor. Ekranlar bor, tenant chegarasi model qatlamida majburlangan.
 
 ---
 

--- a/docs/startup/05-agent-protokoli.md
+++ b/docs/startup/05-agent-protokoli.md
@@ -61,12 +61,29 @@ POST /api/agent/v1/heartbeat
     { "device_id": "dev_...", "status": "error", "error": "auth_failed" }
   ]
 }
-→ { "server_time": "...", "agent_upgrade": null, "secret_rotation": null }
+→ { "server_time": "...", "agent_upgrade": null, "secret_rotation": null,
+    "devices_registered": 0 }
 ```
 
 Bulut 90 soniya heartbeat kelmasa agentni `offline` deb belgilaydi va HR ga Telegram signal yuboradi.
 
 Qurilma holatlari: `online` | `offline` | `error`. `error` — qurilma javob beradi, lekin ishlay olmaydi (masalan parol noto'g'ri).
+
+**Heartbeat terminalni ro'yxatdan ham o'tkazadi.** Bulut ko'rmagan `device_id`
+kelsa, u o'sha agentning tashkiloti va filialida yaratiladi. Aks holda terminallar
+ro'yxatini faqat qo'lda to'ldirish mumkin bo'lardi — bu esa LAN'da haqiqatan turgan
+narsa emas, tilak ro'yxati. Qaysi terminallar borligini operator emas, agent biladi.
+
+`devices_registered` — shu heartbeat nechta yangi terminal yaratganini aytadi. Jim
+o'tgan heartbeat'ni taxmin qilish o'rniga ko'rish uchun.
+
+Bir tashkilot ichida boshqa agent egallagan `device_id` **tegilmaydi**. Ikki filial
+bir xil terminal id ishlatishi — o'rnatishdagi xato, va terminalni jimgina bir
+filialdan boshqasiga ko'chirish uning o'tishlarini noto'g'ri tabelga tushirardi.
+
+`device_id` **tashkilot ichida** unique, butun o'rnatma bo'yicha emas. Dedup
+kalitidan farqli o'laroq, bu yerda to'qnashuv kutiladigan hol: id ni agentni
+o'rnatgan odam yozadi va ikkinchi mijoz ham `dev_kirish` deb nomlaydi.
 
 ### 3.2. Vazifalarni olish — long-poll
 

--- a/docs/startup/README.md
+++ b/docs/startup/README.md
@@ -17,7 +17,7 @@ Ushbu katalog `hikvision-isapi` paketini to'laqonli mahsulotga aylantirish rejas
 |---|---|---|
 | `hikvision-isapi` | MIT ochiq SDK, distribusiya kanali | v2.0.0-beta.1 |
 | `attendance-agent` | Mijoz LAN'idagi edge agent (yopiq) | Sprint 1 yakunlandi |
-| `attendance-cloud` | Bulut xizmati (yopiq) | Agent API tayyor, UI yo'q |
+| `attendance-cloud` | Bulut xizmati (yopiq) | Sprint 2 yakunlandi — agent API + HR paneli |
 
 ## Qabul qilingan asosiy qarorlar
 


### PR DESCRIPTION
Documentation only — nothing in `src/` or `tests/` moves.

Sprint 2 is done. The cloud has memberships, roles and a tenant scope enforced in the model layer, plus a Filament panel with branches, agents, terminals and the event log. The code lives in `attendance-cloud` (PRs #1–#3 there).

## Three departures from the plan, written down rather than absorbed

| Plan | Actual | Why |
|---|---|---|
| `davomat-cloud` | `attendance-cloud` | The repo was created under that name in Sprint 1 |
| Laravel 12 + Filament v4 | Laravel 13 + Filament v5 | Both shipped; picking the older one is nothing but debt |
| Redis / Horizon | Neither | There are no background jobs yet. The queue is on the `database` driver |

## What only surfaced when the thing was actually run

The roadmap's demo is "an agent connects, its terminal appears, swipes flow in". Running it with a real agent process against a served cloud found three defects, none of which any test suite had complained about.

1. **Terminals never appeared.** The panel listed devices, but nothing created them — the list could only be filled in by hand. That is a wish list, not what the LAN contains, and it is the agent that knows which terminals are there. The heartbeat now registers unknown ones.

2. **`devices.device_id` was unique across the installation.** Fine for a hash, wrong for a name a person types. The second customer to call a terminal `dev_kirish` could not register it at all. Now unique per organization.

3. **Livewire's update endpoint does not re-run the panel's middleware** unless it is registered as persistent. A table was therefore scoped on first render and unscoped on every click after it — the worst shape a leak can take, because the screen looks correct until someone sorts a column.

## Two wrong tests before a right one

The third finding took three attempts, and the roadmap records all of them rather than only the outcome:

- `Livewire::test()` cannot see the problem: its render helper disables middleware, so the tenant is absent whether or not the panel is configured correctly. I initially misread a truncated test run as evidence to the contrary.
- The first test built on a *real* request still passed for the wrong reason — a test reuses one container across the page load and the update, so the page's tenant leaked into the update.

Only after both were fixed does the test fail when the flag is removed, which is the only thing that makes it worth keeping.

## Also updated

- `05-agent-protokoli.md` — the heartbeat now describes device registration, `devices_registered` in the response, and what happens when an id in the same organization is already taken.
- `docs/startup/README.md` — the repo table.

The demo section is honest about two limits: `event_type` still comes back `unknown` because the major/minor code map needs a real terminal (same reason `04-paket-mustahkamlash.md` §B stays open), and signing into the panel with a browser was not part of the live run — that path is covered by HTTP feature tests instead.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KHKu4bR2ahNKw3E7nLbr3n)_