### PR TITLE
docs: record Sprint 3 and what running it found

### DIFF
--- a/docs/startup/03-yol-xaritasi.md
+++ b/docs/startup/03-yol-xaritasi.md
@@ -158,21 +158,71 @@ Bulut skeleti tayyor. Ekranlar bor, tenant chegarasi model qatlamida majburlanga
 
 ---
 
-## Sprint 3 — Xodimlar va sinxronizatsiya (2 hafta)
+## Sprint 3 — Xodimlar va sinxronizatsiya (2 hafta) — ✅ BAJARILDI 2026-08-26
 
 **Karta birinchi, yuz keyin** — karta ancha oddiy va pilotni tezlashtiradi.
 
-- [ ] `employees`, `credentials`, `sync_states`, `sync_jobs` jadvallari
-- [ ] `employee_no` ketma-ketligi (tashkilot ichida global, qayta ishlatilmaydi)
-- [ ] Filament: xodim CRUD, Excel'dan import
-- [ ] Reconciler: `desired_hash != applied_hash` → vazifa yaratish
-- [ ] Agent tomonida vazifa bajarish: person → card
-- [ ] Idempotentlik kaliti, retry + backoff, `failed` holati va sababi ekranda
-- [ ] Qurilma imkoniyatlari va sig'imini o'qish
-- [ ] Voqeani xodimga bog'lash (`employee_no` orqali)
+- [x] `employees`, `credentials`, `sync_states`, `sync_jobs` jadvallari
+- [x] `employee_no` ketma-ketligi (tashkilot ichida global, qayta ishlatilmaydi)
+- [x] Filament: xodim CRUD, Excel/CSV dan import
+- [x] Reconciler: `desired_hash != applied_hash` → vazifa yaratish
+- [x] Agent tomonida vazifa bajarish: person → card
+- [x] Idempotentlik kaliti, retry, `failed` holati va sababi ekranda
+- [x] Voqeani xodimga bog'lash (`employee_no` orqali)
+- [ ] Qurilma imkoniyatlari va sig'imini o'qish — **real terminal kerak**
 
-### ✅ Demo
-HR 50 ta xodimni Excel'dan yuklaydi → hammasi terminalga tushadi → kartani bosgan odam ekranda ism bilan ko'rinadi.
+### Rejadan farqlar
+
+| Reja | Amalda | Sabab |
+|---|---|---|
+| `person.upsert` + `card.upsert` alohida vazifalar | Bitta `employee.sync` | `sync_states` da bitta `applied_hash` bor. Bo'lingan vazifalar qisman muvaffaqiyat beradi — odam qo'llandi, karta yo'q — buni bitta hash ifodalay olmaydi. Boshqa joyda kuzatish esa aynan shu model qochadigan "niyatlar navbati"ni qaytadan yaratardi |
+| Agentda backoff: 5s, 15s, 60s, 300s | Bulutning visibility timeout'i | Agent bir oqimli. Tick ichida besh daqiqa uxlash uni terminal callback'larini qabul qilishdan to'xtatadi, va karta yozuvini qayta urinish uchun haqiqiy o'tishni yo'qotish — noto'g'ri almashuv. Qayta uriniladigan xato umuman xabar qilinmaydi; bulut vazifani qaytadan beradi |
+
+### Xodim raqami — nega bu shunchalik muhim
+
+`employee_no` — o'tishni odamga bog'laydigan **yagona** narsa, terminal boshqa hech nima yubormaydi. Shuning uchun hisoblagich faqat oldinga yuradi: xodimni o'chirish raqamni qaytarmaydi, muvaffaqiyatsiz import ham. Ikki marta berilgan raqam avvalgi egasining tarixini jimgina qayta yozadi — o'tgan mart oyidagi davomati boshqa odamniki bo'lib qoladi.
+
+Voqealar xodimga `employee_no` orqali bog'lanadi, ingest paytida olingan foreign key orqali emas. Voqealar odam bulutda paydo bo'lishidan **oldin** kelishi odatiy hol; ingest paytidagi kalit o'sha qatorlarni abadiy nomsiz qoldirardi. Raqam orqali moslashtirish esa xodimni ertaga yaratsangiz, u allaqachon qilgan har bir o'tishni nomlaydi.
+
+### ✅ Demo — o'tkazildi
+
+Haqiqiy agent jarayoni, haqiqiy bulut, digest autentifikatsiyasini talab qiladigan o'rindosh terminal:
+
+```
+CSV dan 3 xodim import           → 3 xodim, 2 tasida karta
+agent enroll, terminal paydo     → dev_kirish, online, qo'lda qadamsiz
+attendance:reconcile             → 3 vazifa navbatga
+agent oldi va qo'lladi           → digest challenge → autentifikatsiyalangan yozuv → succeeded
+                                   3 ta sync state ham applied va sinxron
+xodim nomini o'zgartirish        → 1 vazifa, qo'llandi, qayta sinxron
+qurilma paroli noto'g'ri         → 1 urinishda failed, kind=authentication, qayta urinilmadi
+                                   qolgan ikkitasi applied bo'lib qoldi
+parol tuzatildi, retry bosildi   → tiklangan vazifa muvaffaqiyatli, hammasi sinxron
+```
+
+Terminal o'rindosh — digest talab qiladi va nima so'ralganini yozib boradi. Ya'ni bu zanjirni **simgacha** isbotlaydi, jumladan `DigestAuthenticator` haqiqatan challenge qiladigan serverda ishlashini (buni hech qanday test qoplamagan edi). Hikvision proshivkasi bu payloadlarni qabul qiladimi — buni isbotlamaydi. U real qurilmagacha tasdiqlanmagan bo'lib qoladi.
+
+### Demo nimani ko'rsatdi
+
+Ekranda operatorga quyidagi matn chiqdi:
+
+```
+Client error: `PUT http://127.0.0.1:8899/ISAPI/AccessControl/UserInfo/SetUp?format=json`
+resulted in a `401 Unauthorized` response
+```
+
+Sinxronizatsiya ekrani "men bu odamni bir soat oldin qo'shdim — nega kira olmayapti?" degan savolga javob berish uchun bor. Bu matn hech qanday javob bermaydi, ustiga-ustak terminalning LAN manzilini HR ekraniga chiqarib qo'yadi. Endi xato turi bo'yicha tarjima qilinadi: "Terminal parolni qabul qilmadi. Qurilma parolini tekshiring."
+
+### Yozish jarayonida topilgan uchta nuqson
+
+1. **Muvaffaqiyatsiz vazifa juftlikni abadiy to'sib qo'yardi.** Idempotentlik kaliti unique, va "shu kalitli vazifa bor bo'lsa o'tkazib yubor" degani — xohlangan holat o'zgarib keyin qaytganda (odam bo'shatilib qayta tiklanganda, karta bekor qilinib qaytadan berilganda) ish umuman navbatga tushmasdi.
+2. **Natijadagi dublikat tekshiruvi teskari ishlardi.** Kalit endi navbatga qo'yishda beriladi, ya'ni uni taqqoslash **birinchi** natijani dublikat deb hisoblab, hech qanday natijani yozmasdi.
+3. **Import birovning kartasini jimgina ko'chirib olardi.** Forma buni validatsiya bilan rad etardi, importda esa bunday qoida yo'q edi — ro'yxatda birovning kartasi bo'lsa, o'sha odam eshikni ocholmay qolardi, import esa "muvaffaqiyatli" deb hisobot berardi.
+
+Agent tomonida PHPStan to'rtinchisini topdi: "qurilma ro'yxatda yo'q" uchun `catch` o'lik edi, chunki shartnomada bu xato e'lon qilinmagan. Vazifa `unsupported` o'rniga ushlanmagan xato bo'lib chiqardi.
+
+### 🚦 Gate
+Zanjir uchdan-uchgacha ishlaydi. Sinxronizatsiya modeli o'zgartirilmaydi.
 
 ---
 

--- a/docs/startup/05-agent-protokoli.md
+++ b/docs/startup/05-agent-protokoli.md
@@ -136,17 +136,29 @@ Bir so'rovda ko'pi bilan 500 voqea. `dedup_key` bulutda unique index — takror 
 
 ## 4. Vazifa turlari
 
-| Tur | Yuk | Izoh |
-|---|---|---|
-| `person.upsert` | employee_no, ism, faollik | Birinchi bo'lib bajariladi |
-| `person.delete` | employee_no | |
-| `person.set_enabled` | employee_no, enabled | Obuna/ishdan bo'shash uchun |
-| `card.upsert` | employee_no, card_no | `person.upsert` dan keyin |
-| `face.upsert` | employee_no, image_base64 | Eng oxirida; rasm faqat shu vazifada bo'ladi |
-| `device.probe` | — | Model, firmware, imkoniyat, sig'im |
-| `device.configure_webhook` | agent_url | Qurilmaga lokal agent manzilini yozadi |
+> **Tuzatish (2026-08-26):** `person.*` va `card.*` alohida turlari bitta
+> `employee.sync` bilan almashtirildi. Sabab quyida.
 
-Agent bitta qurilma uchun vazifalarni **ketma-ket** bajaradi (terminal parallel so'rovlarda beqaror), turli qurilmalarni parallel.
+| Tur | Yuk | Holat |
+|---|---|---|
+| `employee.sync` | device_id, employee_no, full_name, enabled, card_no | ✅ ishlaydi |
+| `face.upsert` | employee_no, image_base64 | Rejada; kesish ro'yxatida birinchi |
+| `device.probe` | — | Rejada; real terminal kerak |
+| `device.configure_webhook` | agent_url | Rejada; real terminal kerak |
+
+**Nega bitta vazifa, alohida `person` va `card` emas.** Bulut har bir (xodim,
+qurilma) juftligi uchun bitta `applied_hash` saqlaydi. Bo'lingan vazifalar qisman
+muvaffaqiyat holatini keltirib chiqaradi — odam qo'llandi, karta yo'q — va buni
+bitta hash ifodalay olmaydi. Buni boshqa joyda kuzatish esa aynan shu
+desired-state modeli qochadigan "niyatlar navbati"ni qaytadan yaratardi. Bitta
+vazifa, bitta natija, ko'chiriladigan bitta hash.
+
+`employee.sync` ichida tartib: **person → card**. Kartani terminal hech qachon
+eshitmagan odamga biriktirib bo'lmaydi. `card_no` `null` bo'lsa, qurilmadagi
+karta o'chiriladi — bekor qilingan karta eshikda qolsa, u hamon ochadi.
+
+Agent bitta qurilma uchun vazifalarni **ketma-ket** bajaradi (terminal parallel
+so'rovlarda beqaror), turli qurilmalarni parallel.
 
 ## 5. Xatolar va qayta urinish
 
@@ -154,12 +166,26 @@ Agent xatoni SDK'ning exception ierarxiyasidan oladi (`HikvisionException::isRet
 
 | Xato | Retryable | Agent nima qiladi |
 |---|---|---|
-| `DeviceUnreachableException` | ha | Backoff: 5s, 15s, 60s, 300s; keyin `failed` |
+| `DeviceUnreachableException` | ha | Xabar qilinmaydi; bulut vazifani qaytadan beradi (pastga qarang) |
 | `DeviceBusyException` | ha | Xuddi shunday |
 | `AuthenticationException` | yo'q | Darhol `failed`, qurilma `error` holatiga o'tadi, HR ga signal |
 | Boshqa `HikvisionException` | yo'q | `failed`, xato matni bilan |
 
+> **Tuzatish (2026-08-26):** agentda joyida backoff (5s, 15s, 60s, 300s)
+> qilinmaydi. Agent bir oqimli: tick ichida besh daqiqa uxlash uni terminal
+> callback'larini qabul qilishdan to'xtatadi, va karta yozuvini qayta urinish
+> uchun haqiqiy o'tishni yo'qotish — noto'g'ri almashuv. Buning o'rniga qayta
+> uriniladigan xato **umuman xabar qilinmaydi**: bulutning visibility oynasi
+> vazifani navbatga qaytaradi, va bulut allaqachon sanayotgan `attempts` qachon
+> to'xtashni hal qiladi. Backoff — o'sha visibility oynasi.
+
 Bulut tomonida: `failed` vazifa ekranda sababi bilan ko'rinadi va qo'lda qayta urinish tugmasi bo'ladi. Avtomatik cheksiz qayta urinish yo'q — bu qurilmani bo'g'adi.
+
+Sabab ekranga **tarjima qilib** chiqariladi. Agentning xom matni Guzzle
+istisnosi bo'lib, terminalning LAN manzilini o'z ichiga oladi; ekran esa nima
+qilish kerakligini ko'rsatadi ("Terminal parolni qabul qilmadi. Qurilma parolini
+tekshiring."). Xom matn vazifa qatorida qoladi — debug qilayotgan odam o'sha
+yerga qaraydi.
 
 ## 6. Voqealar oqimi — uch qatlam
 

--- a/docs/startup/README.md
+++ b/docs/startup/README.md
@@ -16,8 +16,8 @@ Ushbu katalog `hikvision-isapi` paketini to'laqonli mahsulotga aylantirish rejas
 | Repo | Rol | Holat |
 |---|---|---|
 | `hikvision-isapi` | MIT ochiq SDK, distribusiya kanali | v2.0.0-beta.1 |
-| `attendance-agent` | Mijoz LAN'idagi edge agent (yopiq) | Sprint 1 yakunlandi |
-| `attendance-cloud` | Bulut xizmati (yopiq) | Sprint 2 yakunlandi — agent API + HR paneli |
+| `attendance-agent` | Mijoz LAN'idagi edge agent (yopiq) | Sprint 3 — vazifalarni terminalda bajaradi |
+| `attendance-cloud` | Bulut xizmati (yopiq) | Sprint 3 yakunlandi — xodimlar, import, reconciler |
 
 ## Qabul qilingan asosiy qarorlar
 


### PR DESCRIPTION
Documentation only — nothing in `src/` or `tests/` moves.

Sprint 3 is done except one item: **reading a terminal's capabilities and capacity**, which needs hardware. Employees, cards, the never-reused number sequence, the reconciler, job execution on the agent, the Excel/CSV import, and events linked to people are all in and merged.

## Two departures from the spec, both for the same reason

| Spec | Actual | Why |
|---|---|---|
| `person.upsert` + `card.upsert` as separate jobs | One `employee.sync` | The cloud keeps one `applied_hash` per (employee, device). Split jobs produce a partial success — person applied, card failed — that one hash cannot express, and tracking it elsewhere would recreate the queue-of-intentions the desired-state model exists to avoid |
| Agent backs off in place: 5s, 15s, 60s, 300s | The cloud's visibility timeout | The agent is single-threaded. Sleeping five minutes inside a tick stops it accepting terminal callbacks, and losing a real swipe to retry a card write is the wrong trade. A retryable failure is simply not reported; the cloud hands the job back |

Both are now in `05-agent-protokoli.md` as dated corrections rather than left to be rediscovered from the code.

## The demo ran, against a terminal that challenges

```
import 3 people from a CSV      → 3 employees, 2 with cards
agent enrols, terminal appears  → dev_kirish, online, no manual step
attendance:reconcile            → 3 jobs queued
agent polls and applies         → digest challenge → authenticated write → succeeded
                                  all 3 sync states applied and synchronised
rename an employee              → 1 job queued, applied, re-synchronised
wrong device password           → failed in 1 attempt, kind=authentication, not retried
                                  the other two stay applied
fix password, press retry       → revived job succeeds, all 3 synchronised again
```

The terminal was a stand-in that demands digest auth and records what it was asked to do. So this proves the chain **up to the wire** — including that `DigestAuthenticator` works against a server that actually challenges, which no test covered. It proves nothing about whether real Hikvision firmware accepts these payloads; that stays unverified, and the docs say so in as many words.

## What the run put on screen

```
Client error: `PUT http://127.0.0.1:8899/ISAPI/AccessControl/UserInfo/SetUp?format=json`
resulted in a `401 Unauthorized` response
```

The sync screen exists so an operator can answer "I added this person an hour ago — why can't they get in?". That answers nothing, and puts a terminal's LAN address on an HR screen. Reasons are now translated (fixed in attendance-cloud #8).

## Four defects, recorded rather than smoothed over

1. **A failed job blocked its pair forever.** The idempotency key is unique, so "skip if a job with this key exists" stranded a pair the moment a desired state changed and changed back — deactivate and reinstate, revoke and reissue a card.
2. **The duplicate check ran backwards.** The key is assigned when the job is *queued*, so comparing it would have called the very first result a duplicate and recorded no outcome at all.
3. **The import silently reassigned somebody else's card.** The form refuses that with a validation rule; the importer had none, so a sheet listing a card someone else holds would have taken it off them and reported success.
4. **A dead catch on the agent**, found by PHPStan: the contract never declared the unregistered-device error, so the branch could not run and the job would have surfaced as an uncaught error instead of `unsupported`.

## Also updated

- `05-agent-protokoli.md` — the job table, the ordering rule inside `employee.sync`, the retry correction, and the translated failure reason.
- `docs/startup/README.md` — the repo table.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KHKu4bR2ahNKw3E7nLbr3n)_