### PR TITLE
Yuz va parollarni stack trace'dan olib tashlash (C5) + C3 hujjati

### DIFF
--- a/docs/startup/03-yol-xaritasi.md
+++ b/docs/startup/03-yol-xaritasi.md
@@ -641,6 +641,29 @@ hech qachon qayta ishlatmaslik kerak** — yangi raqam qo'yish arzonroq.
 
 ---
 
+## Sprint 8 — Paket va chegaralarni mustahkamlash (davom etmoqda, 2026-08-27)
+
+Sprint 7 kabi, bu ham dalildan aniqlandi: `04-paket-mustahkamlash.md` §C.
+
+- [x] **C5** — yuz va parollar stack trace'ga tushishi (SDK + agent image'i)
+- [x] **C3** — vendor chegarasi haqiqiy qilindi va **majburiy tekshiruvga**
+      qo'yildi
+- [ ] C4 — xato tasnifini yakunlash
+- [ ] C6 — batch va rate limit
+- [ ] C2 — `device.profile` ← **qurilma kerak**
+
+SDK testlari 108 → **127**, agent 244 → **293**.
+
+Ikkalasi ham "allaqachon bajarilgan" ko'rinardi va ikkalasi ham bajarilmagandi.
+C5 log qatorlari haqida deb o'ylangandi — aslida stack trace haqida edi, va
+rasmiy PHP image'ining sozlamasiz holati aynan sizib chiqadigan holat ekan.
+C3 uchun interfeyslar bor edi, lekin **nosozlik lug'ati** vendorniki bo'lib
+qolgandi.
+
+Batafsili `04-paket-mustahkamlash.md` §C da.
+
+---
+
 ## Umumiy vaqt jadvali
 
 | Bosqich | Sprint | Taxminiy sana |

--- a/docs/startup/03-yol-xaritasi.md
+++ b/docs/startup/03-yol-xaritasi.md
@@ -573,9 +573,10 @@ qiladi.
 - [x] **B2 — `EventService::count()` doim 0 qaytarardi**
 - [x] **B3 — sahifalashni qachon to'xtatishni bilib bo'lmasdi** — `all()`
       generatorlari
-- [ ] Agentni yangi SDK ga o'tkazish ← **yangi beta tegi kerak**
+- [x] Agentni yangi SDK ga o'tkazish (`v2.0.0-beta.3`)
 
-SDK testlari 88 → **108**.
+PR: SDK (master), agent #6. SDK testlari 88 → **108**, agent 244 → **243**
+(sakkizta pager testi o'rniga yettita collector testi).
 
 ### Nega bu Sprint 7 bo'ldi
 
@@ -609,11 +610,34 @@ tashlab sinaldi: uchta test yiqiladi (avval ikkita edi).
 
 Bu sessiyada uchinchi marta "o'tadigan, lekin himoya qilmaydigan" test yozdim.
 
-### Keyingi qadam
+### Agent tomoni yopildi
 
-Agent SDK'ni Packagist'dan `v2.0.0-beta.1` sifatida oladi, ya'ni `all()` ni
-ishlata olmaydi. **Yangi beta tegi kerak**, keyin agent `RosterPager` o'rniga
-SDK ning to'g'ri yurishini ishlatadi.
+`RosterPager` o'chirildi. U `PersonService::search()` ishonchsiz bo'lgani uchun
+mavjud edi, va uning asosiy himoyasi — "to'liq sahifa hech kimni qo'shmadi,
+demak firmware nol-sahifani qayta beryapti" — katta ehtimol bilan **bizning
+o'z SDK'imizni** ta'riflab turgan edi. Endi qurilma bu savolga o'zi javob
+beradi, va bu yerda taxmin qilish faqat ikkinchi fikr bo'lardi.
+
+O'rniga `RosterCollector` qoldi va u faqat bitta narsani hal qiladi: **qachon
+yurishga ishonishni to'xtatish**. `searchResultPosition` ni e'tiborsiz
+qoldiradigan firmware bir xil yozuvlarni cheksiz oqizishi mumkin, va chegarasiz
+yurish agentning tick'ini ushlab qolardi — o'sha tick terminal callback'lariga
+ham javob berishi kerak.
+
+Chegaraga yetish **to'liq bo'lmagan ro'yxat** deb hisoblanadi, hech qachon
+to'liq deb emas — ya'ni bulut yo'qliklarni drift deb qabul qilmaydi. Uchta
+holat aynan shuning uchun qo'shilgan edi va refaktordan keyin ham saqlanib
+qoldi.
+
+### Reliz chiqarishda yo'qotilgan vaqt
+
+`v2.0.0-beta.2` ikki marta noto'g'ri chiqdi: birinchi marta branch master'ga
+qo'shilmasdan teg qo'yildi, ikkinchi marta teg o'chirilib qayta qo'yildi —
+lekin **Packagist allaqachon ko'rgan versiyani qayta o'qimaydi**. Uning uchun
+versiya o'zgarmas.
+
+Shuning uchun `v2.0.0-beta.3` chiqarildi. Xulosa oddiy: **chiqarilgan tegni
+hech qachon qayta ishlatmaslik kerak** — yangi raqam qo'yish arzonroq.
 
 ---
 

--- a/docs/startup/04-paket-mustahkamlash.md
+++ b/docs/startup/04-paket-mustahkamlash.md
@@ -170,6 +170,50 @@ Agentda retry siyosati aynan shu tasnifga tayanadi (`02-arxitektura.md` §5).
 ### C5. Redaction helper
 Yuz rasmi (base64) hech qachon logga, exception xabariga yoki stack trace'ga tushmasligi kerak. Markazlashtirilgan `Redactor::payload(array $data): array` va logging joylarida majburiy ishlatish + test.
 
+### ✅ C5 — tuzatildi (Sprint 8), lekin boshqa yo'l bilan
+
+`Redactor` helper yozilmadi — kerak emas edi. Muammo log qatorlarida emas,
+**stack trace'da** ekan.
+
+PHP har bir chaqiruv argumentini trace'ga yozadi, agar `zend.exception_ignore_args`
+aks holda aytmasa. Uning kompilyatsiya defaulti — **yozish**, va rasmiy
+`php:*-alpine` image'lari faol `php.ini` bilan kelmaydi. Ya'ni "hech narsa
+sozlanmagan" holat — aynan sizib chiqadigan holat, va agent image'i shunday edi.
+
+Taxmin qilinmadi, sinab ko'rildi: ini'siz PHP'da xato otilganda base64 yuz
+`getTrace()` ga **to'liq** tushadi.
+
+Yechim ikki qavatli, va ikkalasi ham kerak:
+
+1. **SDK** — o'ziga tegishli hamma narsa `#[\SensitiveParameter]` bilan
+   belgilandi (yuz baytlari, parollar, so'rov tanalari, `$options`). Bu INI
+   dan qat'i nazar ishlaydi.
+2. **Agent image'i** — `php.ini-production` faollashtirildi. SDK Guzzle'ning
+   parametrlarini belgilay olmaydi, so'rov `$options` esa ham tanani, ham
+   `auth` ma'lumotlarini olib o'tadi. O'sha chegaradan pastda faqat shu
+   sozlama qoladi.
+
+Birinchisi yolg'iz yetarli emas, ikkinchisi yolg'iz kod xossasi emas.
+
+### Test yozishda ikki marta aldandim
+
+**Birinchi test Mockery bilan yozilgan edi va befoyda chiqdi.** Mockery
+yaratgan sinf parametr atributlarini tashlab yuboradi, va bundan yomoni —
+u **qabul qilgan argumentlarni o'zida saqlaydi**. `print_r($e->getTrace())`
+mock'ning ichki daftariga kirib borib, yuzni o'sha yerdan topardi. Test
+yiqilardi, ishlab chiqarish yo'li esa toza edi.
+
+**Ikkinchisi tasodifan o'tardi.** Nazorat testi ("atributsiz parametr
+haqiqatan sizadimi") trace'ni paket sinflari bo'yicha filtrlardi — va test
+sinfining o'zi ham `Shaykhnazar\HikvisionIsapi\` prefiksida bo'lgani uchun
+filtrdan o'tib ketardi. Endi u freymdan to'g'ridan-to'g'ri o'qiydi.
+
+### Yo'l-yo'lakay topilgan nuqson
+
+`timeout` va `verify_ssl` qurilma konfiguratsiyasidan **defaultsiz** o'qilardi.
+Ularsiz konfiguratsiya butunlay yaroqli — agent ularni beradi, qo'lda yozilgani
+ko'pincha bermaydi — va bu har bir so'rovda PHP warning chiqarardi.
+
 ### C6. Batch va rate limit
 `CardService::batchAdd()` bor, lekin qurilma limitlari hisobga olinmagan. Batch o'lchami sozlanadigan bo'lsin va chaqiruvlar orasida throttle imkoniyati bo'lsin.
 

--- a/docs/startup/04-paket-mustahkamlash.md
+++ b/docs/startup/04-paket-mustahkamlash.md
@@ -157,6 +157,55 @@ Implementatsiya bitta: `HikvisionDriver` (mavjud servislarni o'raydi). Mahsulot 
 
 Bu bugun ~4 soat, mahsulot 10 mijozda ishlaganda ~3 hafta.
 
+### ✅ C3 — bajarildi (Sprint 8), lekin boshqa joyda
+
+**Interfeys SDK ga qo'yilmadi — ataylab.** `shaykhnazar/hikvision-isapi` —
+Hikvision mijozi, va ZKTeco drayveri hech qachon unga qo'shilmaydi; u alohida
+paket bo'ladi. Neytral kontrakt drayverlar **iste'mol qilinadigan** joyda
+turishi kerak, ya'ni agentda — va u allaqachon o'sha yerda edi.
+
+**Bajarilgandek ko'rinardi, lekin bajarilmagandi.** `DeviceCommands`,
+`EventSource`, `DeviceInventory` interfeyslari Sprint 1–7 da yozilgan edi.
+Ammo:
+
+- `Device/` dan tashqaridagi **beshta fayl** `HikvisionException` ni nomi bilan
+  tutardi;
+- **uchala kontraktning o'zi** `@throws HikvisionException` deb e'lon qilardi —
+  ikkinchi ishlab chiqaruvchi bajarishi kerak bo'lgan metodlarda.
+
+Ya'ni interfeyslar neytral, **nosozlik lug'ati esa yo'q** edi. Bu bog'liqlikning
+eng sof ko'rinishi: kontraktning o'zi birinchi vendorni nomlab turibdi.
+
+**`DeviceFailure`** — mahsulotning o'z nosozlik turi. U faqat mahsulot amal
+qiladigan ikki narsani olib yuradi: qayta urinish mantiqiymi, va bulut
+saqlaydigan qisqa sabab. Status kodlar, javob tanalari, vendor sinflari
+olib yurilmaydi — mahsulot ular bilan hech narsa qila olmaydi, ya'ni ular log
+qatorining detali, ikki ishlab chiqaruvchi bajarishi kerak bo'lgan kontraktning
+sharti emas.
+
+`FaultReason` yordamchi emas, **tarjimonga** aylandi.
+
+**Oqim shakli ham muhim.** Generator o'z ishini chaqiruvchi iteratsiya
+qilayotganda bajaradi — ya'ni uni *yaratadigan* chaqiruv atrofidagi `try/catch`
+hech narsa ushlamaydi. Vendor xatosi halqa o'rtasida chiqardi, aynan chaqiruvchi
+unga eng tayyor bo'lmagan paytda.
+
+### Qoladigan qismi — majburiy tekshiruv
+
+Hammaning esida turishiga tayangan kafolat — kafolat emas. `VendorIsolationTest`
+ikki narsani tekshiradi: vendor namespace faqat `src/Device/` ostida uchraydi,
+va **hech bir drayver kontrakti uni umuman nomlamaydi**.
+
+Import'ni qaytarib sinaldi — test fayl nomini va nima qilish kerakligini aytib
+yiqiladi. Ikkinchi ishlab chiqaruvchi qo'shilganda, ish tugaganini aytadigan
+narsa — o'sha test.
+
+**Testlarning o'zi ham bog'liqlikning bir qismi edi:** ular vendor xatolarini
+neytral interfeyslarni bajaradigan soxta obyektlarga uzatardi, ya'ni vendor turi
+har bir stsenariyda mahsulot ichidan o'tardi.
+
+Agent testlari 245 → **293**.
+
 ### C4. Xatolarni manba bo'yicha tasniflash
 Hozir `HikvisionException` bitta. Kerak:
 - `DeviceAuthenticationException` — parol noto'g'ri, qayta urinish foydasiz

--- a/src/Authentication/Contracts/AuthenticatorInterface.php
+++ b/src/Authentication/Contracts/AuthenticatorInterface.php
@@ -6,5 +6,5 @@ namespace Shaykhnazar\HikvisionIsapi\Authentication\Contracts;
 
 interface AuthenticatorInterface
 {
-    public function buildAuthOptions(string $username, string $password): array;
+    public function buildAuthOptions(string $username, #[\SensitiveParameter] string $password): array;
 }

--- a/src/Authentication/DigestAuthenticator.php
+++ b/src/Authentication/DigestAuthenticator.php
@@ -8,7 +8,7 @@ use Shaykhnazar\HikvisionIsapi\Authentication\Contracts\AuthenticatorInterface;
 
 class DigestAuthenticator implements AuthenticatorInterface
 {
-    public function buildAuthOptions(string $username, string $password): array
+    public function buildAuthOptions(string $username, #[\SensitiveParameter] string $password): array
     {
         return [
             'auth' => [$username, $password, 'digest'],

--- a/src/Client/HikvisionClient.php
+++ b/src/Client/HikvisionClient.php
@@ -63,7 +63,21 @@ class HikvisionClient
         return $this->httpClient->get($uri, $this->buildOptions());
     }
 
-    public function post(string $endpoint, array $data = [], array $queryParams = []): array
+    /*
+     * Request bodies are marked sensitive so PHP redacts them from stack traces.
+     *
+     * Every write to a terminal carries personal data — a name, a card number, a
+     * base64 face — and PHP records call arguments in a trace unless told not
+     * to. The setting that tells it not to has a compiled default of 0 and is
+     * not set by the official `php:*-alpine` images this ships on, so the
+     * default deployment is the leaking one.
+     *
+     * Marking the entry points was not enough on its own: the assembled payload
+     * is passed onward as an ordinary argument, so the frame for *this* call
+     * recorded the face even when the caller's own parameter was redacted. This
+     * is where the body actually stops.
+     */
+    public function post(string $endpoint, #[\SensitiveParameter] array $data = [], array $queryParams = []): array
     {
         $uri = $this->buildUri($endpoint, $queryParams);
         $options = $this->buildOptions();
@@ -72,7 +86,7 @@ class HikvisionClient
         return $this->httpClient->post($uri, $data, $options);
     }
 
-    public function put(string $endpoint, array $data = [], array $queryParams = []): array
+    public function put(string $endpoint, #[\SensitiveParameter] array $data = [], array $queryParams = []): array
     {
         $uri = $this->buildUri($endpoint, $queryParams);
         $options = $this->buildOptions();
@@ -85,7 +99,7 @@ class HikvisionClient
      * PUT request with forced XML format
      * Used for endpoints that require XML regardless of global format setting
      */
-    public function putXml(string $endpoint, array $data = [], array $queryParams = []): array
+    public function putXml(string $endpoint, #[\SensitiveParameter] array $data = [], array $queryParams = []): array
     {
         // Force XML format in query params
         $queryParams['format'] = 'xml';
@@ -106,14 +120,14 @@ class HikvisionClient
         return $this->httpClient->delete($uri, $this->buildOptions());
     }
 
-    public function postMultipart(string $endpoint, array $multipart = [], array $queryParams = []): array
+    public function postMultipart(string $endpoint, #[\SensitiveParameter] array $multipart = [], array $queryParams = []): array
     {
         $uri = $this->buildUri($endpoint, $queryParams);
 
         return $this->httpClient->postMultipart($uri, $multipart, $this->buildOptions(excludeContentType: true));
     }
 
-    public function putMultipart(string $endpoint, array $multipart = [], array $queryParams = []): array
+    public function putMultipart(string $endpoint, #[\SensitiveParameter] array $multipart = [], array $queryParams = []): array
     {
         $uri = $this->buildUri($endpoint, $queryParams);
 
@@ -146,8 +160,12 @@ class HikvisionClient
         }
 
         return array_merge($this->authOptions, [
-            'timeout' => $device['timeout'],
-            'verify' => $device['verify_ssl'],
+            // Defaulted rather than assumed present. A device entry without
+            // these is otherwise perfectly valid — the agent supplies them, a
+            // hand-written config often will not — and reading them blind turns
+            // that into a PHP warning on every single request.
+            'timeout' => $device['timeout'] ?? 30,
+            'verify' => $device['verify_ssl'] ?? false,
             'headers' => $headers,
         ]);
     }

--- a/src/Client/HttpClient.php
+++ b/src/Client/HttpClient.php
@@ -27,12 +27,26 @@ class HttpClient implements HttpClientInterface
         $this->client = $client ?? new Client;
     }
 
-    public function get(string $uri, array $options = []): array
+    public function get(string $uri, #[\SensitiveParameter] array $options = []): array
     {
         return $this->request('GET', $uri, $options);
     }
 
-    public function post(string $uri, array $data = [], array $options = []): array
+    /*
+     * Request bodies are marked sensitive so PHP redacts them from stack traces.
+     *
+     * Every write to a terminal carries personal data — a name, a card number, a
+     * base64 face — and PHP records call arguments in a trace unless told not
+     * to. The setting that tells it not to has a compiled default of 0 and is
+     * not set by the official `php:*-alpine` images this ships on, so the
+     * default deployment is the leaking one.
+     *
+     * Marking the entry points was not enough on its own: the assembled payload
+     * is passed onward as an ordinary argument, so the frame for *this* call
+     * recorded the face even when the caller's own parameter was redacted. This
+     * is where the body actually stops.
+     */
+    public function post(string $uri, #[\SensitiveParameter] array $data = [], #[\SensitiveParameter] array $options = []): array
     {
         $format = $options['_format'] ?? 'json';
         unset($options['_format']);
@@ -46,7 +60,7 @@ class HttpClient implements HttpClientInterface
         return $this->request('POST', $uri, $options);
     }
 
-    public function put(string $uri, array $data = [], array $options = []): array
+    public function put(string $uri, #[\SensitiveParameter] array $data = [], #[\SensitiveParameter] array $options = []): array
     {
         $format = $options['_format'] ?? 'json';
         unset($options['_format']);
@@ -60,26 +74,26 @@ class HttpClient implements HttpClientInterface
         return $this->request('PUT', $uri, $options);
     }
 
-    public function delete(string $uri, array $options = []): array
+    public function delete(string $uri, #[\SensitiveParameter] array $options = []): array
     {
         return $this->request('DELETE', $uri, $options);
     }
 
-    public function postMultipart(string $uri, array $multipart = [], array $options = []): array
+    public function postMultipart(string $uri, #[\SensitiveParameter] array $multipart = [], #[\SensitiveParameter] array $options = []): array
     {
         $options['multipart'] = $multipart;
 
         return $this->request('POST', $uri, $options);
     }
 
-    public function putMultipart(string $uri, array $multipart = [], array $options = []): array
+    public function putMultipart(string $uri, #[\SensitiveParameter] array $multipart = [], #[\SensitiveParameter] array $options = []): array
     {
         $options['multipart'] = $multipart;
 
         return $this->request('PUT', $uri, $options);
     }
 
-    private function request(string $method, string $uri, array $options): array
+    private function request(string $method, string $uri, #[\SensitiveParameter] array $options): array
     {
         try {
             $response = $this->client->request($method, $uri, $options);

--- a/src/Services/FaceService.php
+++ b/src/Services/FaceService.php
@@ -35,7 +35,18 @@ class FaceService
         return $this->client->get(self::ENDPOINT_CAPABILITIES);
     }
 
-    public function uploadFace(string $employeeNo, string $faceImageBase64, int $fdid = 1): array
+    /**
+     * Face bytes are marked sensitive so PHP redacts them from stack traces.
+     *
+     * Not a nicety. PHP's compiled default is `zend.exception_ignore_args=0`,
+     * and the official `php:*-cli-alpine` images ship no active php.ini — so in
+     * a normal deployment an exception anywhere below this call records the
+     * whole base64 face in `getTrace()`, where the first person to log a trace
+     * publishes somebody's face. `#[\SensitiveParameter]` holds regardless of
+     * how the INI is set, which is the point: this must be a property of the
+     * code and not of the machine it lands on.
+     */
+    public function uploadFace(string $employeeNo, #[\SensitiveParameter] string $faceImageBase64, int $fdid = 1): array
     {
         $endpoint = "/ISAPI/Intelligent/FDLib/{$fdid}/picture";
 
@@ -122,7 +133,7 @@ class FaceService
     public function uploadFaceDataRecord(
         int $fdid,
         string $fpid,
-        string $imageContent,
+        #[\SensitiveParameter] string $imageContent,
         string $faceLibType = 'blackFD',
         array $additionalData = []
     ): array {
@@ -210,7 +221,7 @@ class FaceService
     public function setupFaceData(
         int $fdid,
         string $fpid,
-        string $imageContent,
+        #[\SensitiveParameter] string $imageContent,
         string $faceLibType = 'blackFD',
         array $additionalData = []
     ): array {
@@ -258,7 +269,7 @@ class FaceService
     public function modifyFaceRecord(
         int $fdid,
         string $fpid,
-        string $imageContent,
+        #[\SensitiveParameter] string $imageContent,
         string $faceLibType = 'blackFD',
         array $additionalData = []
     ): array {

--- a/tests/Unit/Services/FaceRedactionTest.php
+++ b/tests/Unit/Services/FaceRedactionTest.php
@@ -1,0 +1,254 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shaykhnazar\HikvisionIsapi\Tests\Unit\Services;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Request;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Shaykhnazar\HikvisionIsapi\Authentication\DigestAuthenticator;
+use Shaykhnazar\HikvisionIsapi\Client\HikvisionClient;
+use Shaykhnazar\HikvisionIsapi\Client\HttpClient;
+use Shaykhnazar\HikvisionIsapi\Services\FaceService;
+
+/**
+ * A face must not survive an exception.
+ *
+ * PHP records call arguments in a stack trace unless told otherwise, and the
+ * setting that tells it otherwise — `zend.exception_ignore_args` — has a
+ * compiled default of 0 and is not set at all by the official `php:*-alpine`
+ * images this ships on. So without `#[\SensitiveParameter]` a single failed
+ * upload puts an entire base64 face into `getTrace()`, and the first person to
+ * log a trace publishes it.
+ *
+ * These tests assert the redaction directly rather than trusting the INI,
+ * because trusting the INI is the mistake: it makes a privacy property depend
+ * on how somebody configured the machine.
+ *
+ * They run against the real client over a stubbed transport. An earlier version
+ * used a Mockery double and was worthless — Mockery's generated class drops
+ * parameter attributes, and worse, it *records the arguments it received*, so
+ * dumping the trace walked into the mock's own bookkeeping and found the face
+ * there. It failed while the production path was clean.
+ *
+ * IMPORTANT, and the reason these tests are scoped to this package's frames:
+ * the attribute is necessary and **not sufficient**. The payload continues into
+ * Guzzle, whose `$options` array carries the body and the `auth` credentials,
+ * and nothing here can annotate Guzzle's parameters. Below this package only
+ * `zend.exception_ignore_args=1` redacts them — so an application shipping this
+ * SDK has to set it. The agent's image does, and asserts so in its own tests.
+ */
+class FaceRedactionTest extends TestCase
+{
+    private const FACE = 'SECRET-FACE-BASE64-PAYLOAD';
+
+    private function service(): FaceService
+    {
+        $guzzle = new Client([
+            'handler' => HandlerStack::create(new MockHandler([
+                new ConnectException('terminal unreachable', new Request('POST', '/')),
+            ])),
+        ]);
+
+        return new FaceService(new HikvisionClient(
+            new HttpClient($guzzle),
+            new DigestAuthenticator,
+            [
+                'default' => 'dev_1',
+                'format' => 'json',
+                'devices' => ['dev_1' => [
+                    'ip' => '192.0.2.1',
+                    'port' => 80,
+                    'username' => 'admin',
+                    'password' => 'SECRET-DEVICE-PASSWORD',
+                    'protocol' => 'http',
+                ]],
+            ],
+        ));
+    }
+
+    /**
+     * Every argument this package's own frames record, flattened.
+     *
+     * Scoped to our own classes on purpose. The payload does not stop at the
+     * edge of this package: it continues into Guzzle, whose `$options` array
+     * carries both the request body and the `auth` credentials, and no attribute
+     * of ours reaches those parameters. Below this package the only thing that
+     * redacts them is `zend.exception_ignore_args`, which is why the agent image
+     * must set it — see the note on the class.
+     *
+     * Deliberately shallow as well: it walks arrays but never descends into
+     * objects. A recursive dump drags in whatever those objects happen to
+     * reference and reports a leak that is not this code's, which is exactly how
+     * the first version of this test fooled itself.
+     */
+    private function recordedArguments(\Throwable $e): string
+    {
+        $flatten = static function (mixed $value) use (&$flatten): string {
+            if (is_array($value)) {
+                return implode(' ', array_map($flatten, $value));
+            }
+
+            return is_scalar($value) ? (string) $value : '';
+        };
+
+        $seen = [];
+
+        foreach ($e->getTrace() as $frame) {
+            $class = $frame['class'] ?? '';
+
+            if (!str_starts_with($class, 'Shaykhnazar\\HikvisionIsapi\\')) {
+                continue;
+            }
+
+            $seen[] = $flatten($frame['args'] ?? []);
+        }
+
+        return implode(' ', $seen);
+    }
+
+    /**
+     * @param  \Closure(FaceService): mixed  $call
+     */
+    private function assertNothingSecretWasRecorded(\Closure $call): void
+    {
+        try {
+            $call($this->service());
+            $this->fail('expected the call to throw');
+        } catch (\Throwable $e) {
+            $recorded = $this->recordedArguments($e);
+
+            $this->assertStringNotContainsString(
+                self::FACE,
+                $recorded,
+                'the face reached the stack trace, where anything logging it would publish it',
+            );
+
+            $this->assertStringNotContainsString(
+                'SECRET-DEVICE-PASSWORD',
+                $recorded,
+                'the device password reached the stack trace',
+            );
+        }
+    }
+
+    public function test_upload_face_records_neither_the_image_nor_the_password(): void
+    {
+        $this->assertNothingSecretWasRecorded(
+            fn (FaceService $faces) => $faces->uploadFace('EMP001', self::FACE),
+        );
+    }
+
+    public function test_upload_face_data_record_records_neither(): void
+    {
+        $this->assertNothingSecretWasRecorded(
+            fn (FaceService $faces) => $faces->uploadFaceDataRecord(1, 'EMP001', self::FACE),
+        );
+    }
+
+    public function test_setup_face_data_records_neither(): void
+    {
+        $this->assertNothingSecretWasRecorded(
+            fn (FaceService $faces) => $faces->setupFaceData(1, 'EMP001', self::FACE),
+        );
+    }
+
+    public function test_modify_face_record_records_neither(): void
+    {
+        $this->assertNothingSecretWasRecorded(
+            fn (FaceService $faces) => $faces->modifyFaceRecord(1, 'EMP001', self::FACE),
+        );
+    }
+
+    /**
+     * The invariant, stated structurally: these parameters must carry the
+     * attribute. A behavioural test alone would quietly start passing for the
+     * wrong reason on a machine whose INI hides arguments anyway.
+     *
+     * @return list<array{class-string, string, string}>
+     */
+    public static function sensitiveParameters(): array
+    {
+        return [
+            [FaceService::class, 'uploadFace', 'faceImageBase64'],
+            [FaceService::class, 'uploadFaceDataRecord', 'imageContent'],
+            [FaceService::class, 'setupFaceData', 'imageContent'],
+            [FaceService::class, 'modifyFaceRecord', 'imageContent'],
+            [HikvisionClient::class, 'post', 'data'],
+            [HikvisionClient::class, 'put', 'data'],
+            [HikvisionClient::class, 'putXml', 'data'],
+            [HikvisionClient::class, 'postMultipart', 'multipart'],
+            [HikvisionClient::class, 'putMultipart', 'multipart'],
+            [HttpClient::class, 'post', 'data'],
+            [HttpClient::class, 'put', 'data'],
+            [HttpClient::class, 'postMultipart', 'multipart'],
+            [HttpClient::class, 'putMultipart', 'multipart'],
+            [DigestAuthenticator::class, 'buildAuthOptions', 'password'],
+        ];
+    }
+
+    /**
+     * @param  class-string  $class
+     */
+    #[DataProvider('sensitiveParameters')]
+    public function test_the_parameter_is_marked_sensitive(string $class, string $method, string $parameter): void
+    {
+        $found = null;
+
+        foreach ((new \ReflectionMethod($class, $method))->getParameters() as $candidate) {
+            if ($candidate->getName() === $parameter) {
+                $found = $candidate;
+                break;
+            }
+        }
+
+        $this->assertNotNull($found, "{$class}::{$method}() has no \${$parameter}");
+        $this->assertNotEmpty(
+            $found->getAttributes(\SensitiveParameter::class),
+            "{$class}::{$method}(\${$parameter}) must be marked #[\\SensitiveParameter]",
+        );
+    }
+
+    /**
+     * The guard rail for the guard rail: proves an unmarked parameter really is
+     * recorded, so the tests above are not passing merely because this PHP is
+     * configured to hide arguments.
+     */
+    public function test_an_unmarked_parameter_really_does_leak(): void
+    {
+        if (ini_get('zend.exception_ignore_args')) {
+            $this->markTestSkipped('this PHP hides all arguments; the leak cannot be demonstrated here');
+        }
+
+        $leaky = static function (string $employeeNo, string $face): void {
+            throw new \RuntimeException('device said no');
+        };
+
+        try {
+            $leaky('EMP001', self::FACE);
+        } catch (\RuntimeException $e) {
+            // Read straight off the frame rather than through
+            // recordedArguments(), which filters to this package's classes. That
+            // filter happens to admit this test's own frames — same namespace
+            // prefix — and a guard rail that passes by coincidence is not one.
+            $recorded = '';
+
+            foreach ($e->getTrace() as $frame) {
+                foreach ($frame['args'] ?? [] as $argument) {
+                    $recorded .= is_scalar($argument) ? (string) $argument : '';
+                }
+            }
+
+            $this->assertStringContainsString(
+                self::FACE,
+                $recorded,
+                'without the attribute the value is recorded — which is why the attribute is needed',
+            );
+        }
+    }
+}


### PR DESCRIPTION
## C5 — muammo log qatorlarida emas edi

C5 log qatorlari uchun `Redactor` helper'ini so'ragan edi. Muammo boshqa joyda chiqdi.

PHP `zend.exception_ignore_args` boshqasini aytmasa, stack trace'ga **har bir chaqiruv argumentini** yozadi. Uning kompilyatsiya defaulti — yozish, va rasmiy `php:*-alpine` image'lari faol `php.ini` bilan kelmaydi. Ya'ni «hech narsa sozlanmagan» holat — aynan sizib chiqadigan holat.

Taxmin qilinmadi, tekshirildi: ini yuklanmagan PHP'da, xato otadigan funksiyaga uzatilgan base64 yuz `getTrace()` ga **to'liq** tushadi.

Bu paketga tegishli hamma narsa endi `#[\SensitiveParameter]` bilan belgilangan — yuz baytlari, parollar, so'rov tanalari, va ham payload'ni ham `auth` ma'lumotlarini olib yuruvchi `$options` massivi. Bu INI dan qat'i nazar ishlaydi.

**Bu kerak, lekin yetarli emas** — va testlar buni ochiq aytadi: payload Guzzle'ga o'tib ketadi, uning parametrlarini bu yerdan hech narsa belgilay olmaydi. O'sha chegaradan pastda faqat INI qoladi, shuning uchun agent image'i `php.ini-production` ni faollashtiradi (alohida repoda).

### Testlar meni ikki marta aldadi

**Birinchisi Mockery bilan yozilgan edi va befoyda chiqdi.** Mockery yaratgan sinf parametr atributlarini tashlab yuboradi, va bundan yomoni — u qabul qilgan argumentlarni o'zida saqlaydi. Trace'ni chop etish mock'ning ichki daftariga kirib borib, yuzni o'sha yerdan topardi. Test yiqilardi, ishlab chiqarish yo'li esa toza edi. Haqiqiy klient va stub transport ustiga qayta yozildi.

**Ikkinchisi tasodifan o'tardi.** Nazorat testi («belgilanmagan parametr haqiqatan sizadimi») trace'ni shu paket sinflari bo'yicha filtrlaydigan helper orqali o'qirdi, test sinfining o'zi esa o'sha namespace prefiksida — shuning uchun filtrdan o'tib ketardi. Endi u freymdan to'g'ridan-to'g'ri o'qiydi.

### Yo'l-yo'lakay topilgan nuqson

`timeout` va `verify_ssl` qurilma konfiguratsiyasidan **defaultsiz** o'qilardi. Ularsiz konfiguratsiya butunlay yaroqli — agent ularni beradi, qo'lda yozilgani ko'pincha bermaydi — va bu har bir so'rovda PHP warning chiqarardi.

## C3 — nega bu repoda emas

C3 vendor-neytral drayver kontraktini so'ragan edi. U ataylab **agentga** qo'yildi: `shaykhnazar/hikvision-isapi` — bu Hikvision klienti, ZKTeco drayveri alohida paket bo'lardi, neytral kontrakt esa drayverlar **iste'mol qilinadigan** joyga tegishli.

Hujjat nima uchun bu ish bajarilgan ko'ringani va bajarilmaganini yozib qo'yadi: interfeyslar Sprint 1-7 dan beri bor edi, lekin `Device/` dan tashqaridagi besh fayl `HikvisionException` ni nomi bilan ushlardi va uchala kontrakt ham ikkinchi ishlab chiqaruvchi amalga oshiradigan metodlarda `@throws HikvisionException` deb turardi.

## Tekshiruv

127 test (7 skip — ular qurilma talab qiladi), PHPStan level 6, Pint toza.

> ⚠️ Merge qilingandan keyin **`v2.0.0-beta.4` tegi kerak.** `beta.3` (`623969a`) allaqachon nashr qilingan va Packagist nashr qilingan versiyani hech qachon qayta o'qimaydi — teg qayta ishlatilmaydi. Bu teg qo'yilmaguncha `#[\SensitiveParameter]` ishi agentga yetib bormaydi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KHKu4bR2ahNKw3E7nLbr3n

---
_Generated by [Claude Code](https://claude.ai/code/session_01KHKu4bR2ahNKw3E7nLbr3n)_